### PR TITLE
[241231_이하성] 기능: 리액트플로 드래그앤드랍으로 컴포넌트 생성 구현

### DIFF
--- a/src/Pages/Home/mingle.tsx
+++ b/src/Pages/Home/mingle.tsx
@@ -15,13 +15,17 @@ import {
 import "@xyflow/react/dist/style.css";
 
 import SITE_SEARCH from "./siteSearch";
-// import ANTD_ALERT from "@/components/_ANTD/ANTD_ALERT";
-// import MUI_ALERT from "@/components/_MUI/MUI_ALERT";
+
 import { X } from "lucide-react";
-import ANTD_BREADCRUMB from "@/components/_ANTD/ANTD_BREADCRUMB";
-import MUI_BREADCRUMB from "@/components/_MUI/MUI_BREADCRUMB";
 
 import { DnDProvider, useDnD } from "./dndContext";
+
+import MUI_ALERT from "@/components/_MUI/MUI_ALERT";
+import ANTD_ALERT from "@/components/_ANTD/ANTD_ALERT";
+import MUI_BREADCRUMB from "@/components/_MUI/MUI_BREADCRUMB";
+import ANTD_BREADCRUMB from "@/components/_ANTD/ANTD_BREADCRUMB";
+import MUI_MENU from "@/components/_MUI/MUI_MENU";
+import ANTD_MENU from "@/components/_ANTD/ANTD_MENU";
 
 const initialNodes = [
   {
@@ -34,12 +38,37 @@ const initialNodes = [
 
 const nodeTypes = {
   SITE_SEARCH,
+  MUI_ALERT,
+  ANTD_ALERT,
   MUI_BREADCRUMB,
   ANTD_BREADCRUMB,
+  MUI_MENU,
+  ANTD_MENU,
 };
 
-let id = 0;
-const getId = () => `dndnode_${id++}`;
+// const prefixes = ["MUI", "ANTD", "CHAKRA", "SHADCN"];
+const menuList = ["Alert", "Menu", "Breadcrumb"];
+
+// prefixes.forEach((prefix) => {
+//   menuList.forEach((menu) => {
+//     const key = `${prefix}_${menu.toUpperCase()}`;
+//     nodeTypes[key] = `${prefix}_${menu.toUpperCase()}`;
+//   });
+// });
+
+// console.log(nodeTypes);
+
+// const loadComponents = async () => {
+//   const imports = {};
+
+//   for (const key in nodeTypes) {
+//     const componentName = nodeTypes[key];
+//     imports[key] = await import(`../../components/Libraries/${componentName}`).then(
+//       (module) => module.default
+//     );
+//   }
+//   console.log(imports);
+// };
 
 function MinglePage() {
   const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes);
@@ -70,6 +99,9 @@ function MinglePage() {
       if (!type) {
         return;
       }
+
+      let id = 0;
+      const getId = () => `dndnode_${id++}`;
 
       // project was renamed to screenToFlowPosition
       // and you don't need to subtract the reactFlowBounds.left/top anymore
@@ -105,7 +137,7 @@ function MinglePage() {
       {
         id: `node-${prev.length + 1}`,
         type: `${currentNode}`,
-        position: { x: 50, y: prev.length * 100 },
+        position: { x: prev.length * 10, y: prev.length * 10 },
         data: { value: `${currentNode}` },
       },
     ]);
@@ -117,6 +149,7 @@ function MinglePage() {
 
     setDrawerOpen((prev) => !prev);
     setSelectedComp(component);
+    console.log(component);
   }
 
   const MUI_COMP = nodeTypes[`MUI_${selectedComp}` as keyof typeof nodeTypes];
@@ -164,11 +197,11 @@ function MinglePage() {
           className="mt-[20px] w-full h-full max-h-[520px] overflow-scroll text-white flex flex-col gap-[20px] px-[10px]"
           style={{ scrollbarColor: "#ffffff transparent" }}
         >
-          <li onClick={onClickComp}>Breadcrumb</li>
-
-          {/* {new Array(30).fill("test").map((el, idx) => (
-            <li>{`${el} ${idx + 1}`}</li>
-          ))} */}
+          {menuList.map((item) => (
+            <li onClick={onClickComp} key={item}>
+              {item}
+            </li>
+          ))}
         </ul>
       </div>
 
@@ -205,7 +238,7 @@ function MinglePage() {
         <div className="w-full border-b-2 border-[#e0e0e0] mt-[20px]"></div>
 
         {/* 컴포넌트 리스트 */}
-        <div className="w-full max-h-[520px] overflow-scroll">
+        <div className="w-full max-h-[520px] overflow-scroll bg-[#f5f5f5] mt-[20px]">
           <div className="px-[10px] mt-[40px] flex flex-col gap-[20px]">
             <div className="flex gap-[20px]">
               <img src="/MUI.svg" alt="mui" className="mt-[4px]" />

--- a/src/Pages/Home/siteSearch.tsx
+++ b/src/Pages/Home/siteSearch.tsx
@@ -1,13 +1,26 @@
-import img from "/naver.png";
 import { KeyboardEvent, useState } from "react";
 
 export default function SITE_SEARCH() {
-  const [testToggle, setTestToggle] = useState(false);
+  const [url, setUrl] = useState<string>("");
+  const [content, setContent] = useState<string>("");
 
-  function handleEnter(e: KeyboardEvent<HTMLInputElement>) {
-    if (e.key === "Enter") {
-      e.preventDefault();
-      setTestToggle(true);
+  async function handleEnter(e: KeyboardEvent<HTMLInputElement>) {
+    if (e.key !== "Enter") return;
+    if (!e.currentTarget.value) return;
+
+    setUrl(e.currentTarget.value);
+
+    try {
+      const response = await fetch("https://naver.com");
+      if (!response.ok) {
+        throw new Error("데이터를 가져오는 데 실패했습니다.");
+      }
+
+      const data = await response.text();
+      setContent(data);
+    } catch (error) {
+      console.error(error);
+      setContent("URL 데이터를 가져오는 데 문제가 발생했습니다.");
     }
   }
 
@@ -23,16 +36,10 @@ export default function SITE_SEARCH() {
           onKeyDown={handleEnter}
         />
       </div>
-      <div className="w-full min-h-[540px] max-h-[1080px] overflow-clip relative bg-white rounded-b-2xl opacity-90">
-        {testToggle && (
-          <>
-            <div className="absolute text-[#ff0000] text-5xl left-[10%]">
-              테스트용 쌩캡쳐 이미지 입니다.
-            </div>
-            <img src={img} />
-          </>
-        )}
-      </div>
+      <div
+        className="w-full min-h-[540px] max-h-[1080px] overflow-clip relative bg-white rounded-b-2xl opacity-90"
+        dangerouslySetInnerHTML={{ __html: content }}
+      ></div>
     </div>
   );
 }

--- a/src/components/_ANTD/ANTD_MENU.tsx
+++ b/src/components/_ANTD/ANTD_MENU.tsx
@@ -1,0 +1,43 @@
+import { DownOutlined, SettingOutlined } from "@ant-design/icons";
+import type { MenuProps } from "antd";
+import { Dropdown, Space } from "antd";
+
+const items: MenuProps["items"] = [
+  {
+    key: "1",
+    label: "My Account",
+    disabled: true,
+  },
+  {
+    type: "divider",
+  },
+  {
+    key: "2",
+    label: "Profile",
+    extra: "⌘P",
+  },
+  {
+    key: "3",
+    label: "Billing",
+    extra: "⌘B",
+  },
+  {
+    key: "4",
+    label: "Settings",
+    icon: <SettingOutlined />,
+    extra: "⌘S",
+  },
+];
+
+export default function ANTD_MENU() {
+  return (
+    <Dropdown menu={{ items }}>
+      <a onClick={(e) => e.preventDefault()}>
+        <Space>
+          Hover me
+          <DownOutlined />
+        </Space>
+      </a>
+    </Dropdown>
+  );
+}

--- a/src/components/_MUI/MUI_MENU.tsx
+++ b/src/components/_MUI/MUI_MENU.tsx
@@ -1,0 +1,44 @@
+import Button from "@mui/material/Button";
+import Menu from "@mui/material/Menu";
+import MenuItem from "@mui/material/MenuItem";
+import { useState } from "react";
+
+export default function MUI_MENU() {
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+
+  const open = Boolean(anchorEl);
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  return (
+    <div>
+      <Button
+        id="basic-button"
+        aria-controls={open ? "basic-menu" : undefined}
+        aria-haspopup="true"
+        aria-expanded={open ? "true" : undefined}
+        onClick={handleClick}
+      >
+        Dashboard
+      </Button>
+      <Menu
+        id="basic-menu"
+        anchorEl={anchorEl}
+        open={open}
+        onClose={handleClose}
+        MenuListProps={{
+          "aria-labelledby": "basic-button",
+        }}
+      >
+        <MenuItem onClick={handleClose}>Profile</MenuItem>
+        <MenuItem onClick={handleClose}>My account</MenuItem>
+        <MenuItem onClick={handleClose}>Logout</MenuItem>
+      </Menu>
+    </div>
+  );
+}


### PR DESCRIPTION
사이드바/드로워 메뉴에서 드래그앤드랍으로 컴포넌트 생성 구현 완료. 기존의 클릭으로도 생성 가능함.

컴포넌트 다이나믹 임폴트와 사이트 검색 시 HTML 꽂는거 시도 중... 백업으로 PR 머지 진행함